### PR TITLE
Fix Encoding::UndefinedConversionError when trying to save the tempfile

### DIFF
--- a/lib/rails_dominant_colors/url.rb
+++ b/lib/rails_dominant_colors/url.rb
@@ -46,7 +46,7 @@ module RailsDominantColors
     end
 
     def tempfile(extension, body)
-      tempfile = Tempfile.open(['source', extension])
+      tempfile = Tempfile.open(['source', extension], binmode: true)
       tempfile.write(body)
       tempfile.close
       tempfile.path


### PR DESCRIPTION
Ruby tries to convert encoding when the image is being saved as text. This causes `Encoding::UndefinedConversionError` when using Url. As we deal with images which are binary data, we have to save them as binary data to avoid such errors.