### PR TITLE
Update the gem versions and fix the run command for mini_magick v5.

### DIFF
--- a/lib/rails_dominant_colors/base.rb
+++ b/lib/rails_dominant_colors/base.rb
@@ -77,19 +77,14 @@ module RailsDominantColors
     end
 
     def execute
-      @execute ||= image.run_command(
-        'convert',
-        image.path,
-        '-format',
-        '%c',
-        '-colors',
-        colors,
-        '-depth',
-        8,
-        '-alpha',
-        'on',
-        'histogram:info:'
-      )
+      @execute ||= MiniMagick.convert do |convert|
+        convert << image.path
+        convert << '-format' << '%c'
+        convert << '-colors' << colors.to_s
+        convert << '-depth' << '8'
+        convert << '-alpha' << 'on'
+        convert << 'histogram:info:'
+      end
     end
 
     def sort_by_size

--- a/lib/rails_dominant_colors/version.rb
+++ b/lib/rails_dominant_colors/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsDominantColors
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/rails_dominant_colors.gemspec
+++ b/rails_dominant_colors.gemspec
@@ -28,11 +28,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler', '~> 2.5'
+  spec.add_development_dependency 'base64', '~> 0.2'
   spec.add_development_dependency 'coveralls', '~> 0.8'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'simplecov', '~> 0.16'
 
-  spec.add_dependency 'mini_magick', '~> 4.10'
+  spec.add_dependency 'mini_magick', '~> 5.0'
 end


### PR DESCRIPTION
Update gems:

- bundler from 2.0 to 2.5
- rake 13.0 to 13.2
- rspec 3.9 to 3.13
- mini_magick 4.10 to 5.0

Fix run command for new mini_magic API.